### PR TITLE
HOTFIX: check if playing in iFrame and make sure assets load in

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,15 +21,34 @@ const router = createBrowserRouter(
     <Route>
       <Route path="/" element={<TitleScreen />} />
       <Route path="main" element={<RootLayout />} />
-      <Route path="*" element={<></>} />
+      <Route path="*" element={<TitleScreen />} />
     </Route>
   )
 );
 
 function App() {
+  window.screen.orientation.lock("landscape").then(
+    (success) => console.log("Orientation locked to landscape", success),
+    (failure) => console.log("Orientation not locked/ not mobile", failure)
+  );
+
   playSlightBackgroundMusic(); //Night Attack on Sanjo Palace theme
 
-  return <RouterProvider router={router} />;
+  /*TODO: BUG:
+  Routing in iFrame on itch.io works, but does not load all assets.
+  Check for iFrame, and use a modal if so, or a router in other cases. */
+  if (window.self !== window.top) {
+    console.log("Page is loaded inside an iframe");
+    return (
+      <>
+        <RouterProvider router={router} />
+        <RootLayout />
+      </>
+    );
+  } else {
+    console.log("not framed");
+    return <RouterProvider router={router} />;
+  }
 }
 
 export default App;

--- a/src/Components/AboutButton.jsx
+++ b/src/Components/AboutButton.jsx
@@ -12,6 +12,7 @@ import {
 
 import very_dark_swatch from "../Assets/Swatches/very_dark_swatch.png";
 import FooterButton from "./FooterButton";
+import { VERSION } from "../VERSION";
 
 import { cleansingBellSFX, slapSFX } from "../Sound/SFX";
 const sfxOnClick = cleansingBellSFX;
@@ -56,7 +57,9 @@ export default function AboutButton() {
               <br />
               "OM" and other sound effects by "Freesound.org" and "Jagadamba"
               <br />
-              "Tubo" icon made with Bing AI, and copyright myCatsName
+              "Tubo" icon made with Bing AI.
+              <br />
+              V.{VERSION}
             </Text>
           </ModalBody>
           <ModalFooter justifyContent="center">

--- a/src/Components/WarningModal.jsx
+++ b/src/Components/WarningModal.jsx
@@ -33,7 +33,8 @@ export default function WarningModal() {
   const handleClick = (preference) => {
     setAllowJumps(preference);
     gameStartSFX.play();
-    navigate("main");
+    //Check if in iFrame (itch.io)
+    window.self === window.top ? navigate("main") : onClose();
     console.log(
       "Jumps: " + preference,
       "\n Title screen modal nav to main layout"

--- a/src/VERSION.js
+++ b/src/VERSION.js
@@ -1,0 +1,1 @@
+export const VERSION = "3.3"


### PR DESCRIPTION
For the itch.io build, some image and art assets would not load when playing in an iFrame when using the router, despite the routing itself working. This is a fix at least until page transitions and testing other fixes. 

- Also adds experimental orientation lock for mobile.