### PR TITLE
HOTFIX: add fallback for viewTransition API

### DIFF
--- a/src/Components/WarningModal.jsx
+++ b/src/Components/WarningModal.jsx
@@ -32,6 +32,9 @@ export default function WarningModal() {
     startTransition(() => {
       setLoadGame(true);
     });
+    if (!document.startViewTransition) {
+      return onClose();
+    }
     document.startViewTransition(() => {
       onClose();
     });

--- a/src/Context/ThemeContext.jsx
+++ b/src/Context/ThemeContext.jsx
@@ -24,6 +24,9 @@ export function ThemeProvider({ children }) {
   const currentTheme = THEMES[themeKeys[themeIndex]];
 
   const nextTheme = () => {
+    if (!document.startViewTransition) {
+      return setThemeIndex((themeIndex + 1) % themeKeys.length);
+    }
     document.startViewTransition(() =>
       setThemeIndex((themeIndex + 1) % themeKeys.length)
     );


### PR DESCRIPTION
function is not supported on firefox browser.
Add a fallback if not supported.